### PR TITLE
Add match for the main website

### DIFF
--- a/always-latest-tweets-for-mobile-twitter.user.js
+++ b/always-latest-tweets-for-mobile-twitter.user.js
@@ -1,10 +1,11 @@
 // ==UserScript==
 // @name         Always Latest Tweets for Mobile Twitter
 // @namespace    https://github.com/gslin/always-latest-tweets-for-mobile-twitter
-// @version      0.20190419.0
+// @version      0.20190501.0
 // @description  Auto-switch to latest tweets for mobile version Twitter
 // @author       Gea-Suan Lin <darkkiller@gmail.com>
 // @match        https://mobile.twitter.com/*
+// @match        https://twitter.com/*
 // @grant        none
 // @run-at       document-start
 // @license      MIT


### PR DESCRIPTION
The mobile PWA version is also used on the main website (if you accept) and it looks like it will be the default soon.